### PR TITLE
Shifting from Wait Command to CustomWaitCommand

### DIFF
--- a/src/main/deploy/pathplanner/autos/Wait Drive Auto.auto
+++ b/src/main/deploy/pathplanner/autos/Wait Drive Auto.auto
@@ -5,9 +5,9 @@
     "data": {
       "commands": [
         {
-          "type": "wait",
+          "type": "named",
           "data": {
-            "waitTime": 5.0
+            "name": "CustomWaitCommand"
           }
         },
         {


### PR DESCRIPTION
CustomWaitCommand would allow the user to customize the wait time for the Wait Drive auto.